### PR TITLE
Update watson analysis endpoint to only show tones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teller AI
 Module 4 | Team: Autumn Martin, Daniel Mulitauopele, Dina Caraballo, Nick Dambrosio
-#### Cross-Pollination Capstone: a project where back-end and front-end students collaborate and build an app together. This app encompasses separate back-end and front-end apps that communicate to each other via API requests.
+Cross-Pollination Capstone: a project where back-end and front-end students collaborate and build an app together. This app encompasses separate back-end and front-end apps that communicate to each other via API requests.
 
 ## About
 ### Intro
@@ -34,40 +34,7 @@ GET /teller/watson_analysis?coin=dogecoin
 
 Example Response:
 ```
-{
-  "document_tone": {
-    "tones": [{
-      "score": 0.638346,
-      "tone_id": "joy",
-      "tone_name": "Joy"
-    }]
-  },
-  "sentences_tone": [{
-    "sentence_id": 0,
-    "text": "Happy New Year Dogecoin!"
-    "tones": [{
-      "score": 0.591348,
-      "tone_id": "joy",
-      "tone_name": "Joy"
-    }]
-  }, {
-    "sentence_id": 1,
-    "text": "Hopefully this year is just as stellar for dogecoin as the last."
-    "tones": [{
-      "score": 0.983475,
-      "tone_id": "tentative",
-      "tone_name": "Tentative"
-    }]
-  }, {
-    "sentence_id": 1,
-    "text": "Wow Dogecoin is just amazing!"
-    "tones": [{
-      "score": 0.967505,
-      "tone_id": "joy",
-      "tone_name": "Joy"
-    }]
-  }
-}
+{ "document_tones": ["joy", "tentative"] }
 ```
 
 ## Getting Started

--- a/teller/tests/test_tone_analysis.py
+++ b/teller/tests/test_tone_analysis.py
@@ -7,19 +7,5 @@ from .. import tone_analysis
 class AnalyzeToneViaWatsonTestCase(TestCase):
     def test_analyze_tone_via_watson_works(self):
         sentance = "Wow this totally works!"
-        expected_result = { "document_tone": {
-                                "tones": [
-                                  {
-                                    "score": 0.625141,
-                                    "tone_id": "joy",
-                                    "tone_name": "Joy"
-                                  },
-                                  {
-                                    "score": 0.97759,
-                                    "tone_id": "confident",
-                                    "tone_name": "Confident"
-                                  }
-                                ]
-                              }
-                          }
+        expected_result = { "document_tones": ["joy","confident"] }
         self.assertEqual(tone_analysis.analyze_tone_via_watson(sentance), expected_result)

--- a/teller/tone_analysis.py
+++ b/teller/tone_analysis.py
@@ -15,4 +15,8 @@ def analyze_tone_via_watson(document):
                 {'text': document},
                 'application/json',
             ).get_result()
-    return result
+    tone_names = []
+    raw_tones = result['document_tone']['tones']
+    for raw_tone in raw_tones:
+        tone_names.append(raw_tone['tone_id'])
+    return { 'document_tones': tone_names }

--- a/teller/twitter_service.py
+++ b/teller/twitter_service.py
@@ -4,7 +4,7 @@ from django.http import JsonResponse
 
 
 def retrieve_twitter_data(query):
-    url = f'https://api.twitter.com/1.1/search/tweets.json?q={query}&lang=en&count=100&result_type=recent'
+    url = f'https://api.twitter.com/1.1/search/tweets.json?q={query}&lang=en&count=100'
     headers = {'authorization': f'Bearer {os.environ.get("twitter_token")}'}
     response = requests.get(url, headers=headers)
     data = response.json()


### PR DESCRIPTION
## Closes #18
- [X] Wrote Tests
- [X] Implemented
- [X] Reviewed

## Necessary checkmarks

- [X] All Tests are Passing
- [X] The code will run locally

## Type of change

- [ ] New feature
- [ ] Bug Fix
- [X] Update

## Description
### Implements
Updates the response for the endpoint `/watson_analysis?coin={coin}` to match new expectations for its response (now that the expectations have been narrowed down). 

After this change, this endpoint returns: `{ "document_tones": ["joy", "tentative"] }`. 

This endpoint used to return: 
```
{
  "document_tone": {
    "tones": [{
      "score": 0.638346,
      "tone_id": "joy",
      "tone_name": "Joy"
    }]
  },
  "sentences_tone": [{
    "sentence_id": 0,
    "text": "Happy New Year Dogecoin!"
    "tones": [{
      "score": 0.591348,
      "tone_id": "joy",
      "tone_name": "Joy"
    }]
  }, {
    "sentence_id": 1,
    "text": "Hopefully this year is just as stellar for dogecoin as the last."
    "tones": [{
      "score": 0.983475,
      "tone_id": "tentative",
      "tone_name": "Tentative"
    }]
  }, {
    "sentence_id": 1,
    "text": "Wow Dogecoin is just amazing!"
    "tones": [{
      "score": 0.967505,
      "tone_id": "joy",
      "tone_name": "Joy"
    }]
  }
}
```

## Check the correct boxes

- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [X] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist

- [X] My code has no commented out code (explanatory comments are fine)
- [X] I have reviewed my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code
