### PR TITLE
Change GitHub language label

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+staticfiles linguist-vendored

--- a/teller/tests/test_views.py
+++ b/teller/tests/test_views.py
@@ -17,3 +17,7 @@ class GetWelcomePage(TestCase):
         response = client.get(reverse('welcome'))
 
         self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'welcome.html')
+        self.assertContains(response, "Teller AI")
+        self.assertContains(response, "GET https://teller-ai.herokuapp.com/teller/watson_analysis?coin=dogecoin")
+        self.assertContains(response, '{ "document_tones": ["joy", "tentative"] }')

--- a/tellerai/urls.py
+++ b/tellerai/urls.py
@@ -20,6 +20,6 @@ from . import views
 
 urlpatterns = [
     path('teller/', include('teller.urls')),
-    path('', views.WelcomePageView.as_view()),
+    path('', views.WelcomePageView.as_view(), name='welcome'),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
- [X] Wrote Tests
- [X] Implemented
- [X] Reviewed

## Necessary checkmarks

- [X] All Tests are Passing

- [X] The code will run locally

## Type of change

- [ ] New feature
- [X] Bug Fix

## Description
### Fixes
Following docs [here](https://github.com/github/linguist#overrides), this adds a .gitattributes file to attempt to fix the GitHub language marker change from Python to CSS after static files were added. 

Also resolves the test failure that occurred due to an update that removed the welcome path name, as well as adds several more assertions. 

## Check the correct boxes

- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [X] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist

- [X] My code has no commented out code (explanatory comments are fine)
- [X] I have reviewed my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code
